### PR TITLE
Solution for Vector Drawable support in Android 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ You can try the demo in one of two ways:
 
 See [app/proguard-rules.pro](app/proguard-rules.pro) for an example.
 
+## Known Issues
+
+- In Android 4.x, there is an issue about Vector Drawable icons. If you want to use Vector Drawable as a icons (e.g `app:buttonIcon="@drawable/ic_add"`, according to this [StackOverflow](https://stackoverflow.com/a/38012842), you need to add the following snippet in your Activity classes.
+
+```
+// Java
+static {
+    AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
+}
+
+// Kotlin
+companion object {
+    init() {
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
+    }
+}
+```
+
 ## Usage & Customisation
 
 **Note:** all of the instructions below assume that the FAB is referenced by the variable `fab`, i.e.


### PR DESCRIPTION
I ran into the problem of using Vector Drawable icons in Android 4.x. As you know, for compatibility with Vector Drawable, the `app:srcCompat` attribute is used, but it's not supported in this library. 
I found a solution by enabling `AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)` in my Activity. This works great and now in Android 4.x I can use Vector Drawable as a FAB icon, and also in a Speed Dial menu.