### PR TITLE
Simplify the method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ The `FloatingActionButton` view must be placed at the **root** of your layout, *
 
 ### FAB Position
 
-The FAB can be positioned in any of the four corners of the activity via XML or with `fab.setButtonPosition(...)`. The default position is the bottom-end corner.
+The FAB can be positioned in any of the four corners of the activity via XML or with `fab.setPosition(...)`. The default position is the bottom-end corner.
 
 	// Java
-	fab.setButtonPosition(POSITION_BOTTOM | POSITION_END);
+	fab.setPosition(POSITION_BOTTOM | POSITION_END);
 
 	// Kotlin
-	fab.setButtonPosition(POSITION_BOTTOM.or(POSITION_END))
+	fab.setPosition(POSITION_BOTTOM.or(POSITION_END))
 
 	// XML
 	<uk.co.markormesher.android_fab.FloatingActionButton
@@ -96,13 +96,13 @@ The FAB can be offset from any of the four edges to precisely control its locati
 
 ### FAB Icon
 
-The icon displayed in the centre of the FAB can be set via XML using a `Drawable` reference or with `fab.setButtonIconResource(...)` using a `Drawable` resource ID. The icon will be centred in a 24dp x 24dp view group, as per the Android Material Design specs.
+The icon displayed in the centre of the FAB can be set via XML using a `Drawable` reference or with `fab.setIconResource(...)` using a `Drawable` resource ID. The icon will be centred in a 24dp x 24dp view group, as per the Android Material Design specs.
 
 	// Java
-	fab.setButtonIconResource(R.drawable.ic_add);
+	fab.setIconResource(R.drawable.ic_add);
 
 	// Kotlin
-	fab.setButtonIconResource(R.drawable.ic_add)
+	fab.setIconResource(R.drawable.ic_add)
 
 	// XML
 	<uk.co.markormesher.android_fab.FloatingActionButton
@@ -113,13 +113,13 @@ The icon displayed in the centre of the FAB can be set via XML using a `Drawable
 
 ### FAB Background Colour
 
-The background colour of the FAB can be set via XML using a colour reference or programmatically with `fab.setButtonBackgroundColour(...)` using an aRGB colour value (e.g. `0xffff9900` for dark orange). Note that the second method does **not** take a colour resource ID, so passing in `R.color.some_colour_name` will not work.
+The background colour of the FAB can be set via XML using a colour reference or programmatically with `fab.setBackgroundColour(...)` using an aRGB colour value (e.g. `0xffff9900` for dark orange). Note that the second method does **not** take a colour resource ID, so passing in `R.color.some_colour_name` will not work.
 
 	// Java
-	fab.setButtonBackgroundColour(0xffff9900);
+	fab.setBackgroundColour(0xffff9900);
 
 	// Kotlin
-	fab.setButtonBackgroundColour(0xffff9900.toInt())
+	fab.setBackgroundColour(0xffff9900.toInt())
 
 	// XML
 	<uk.co.markormesher.android_fab.FloatingActionButton

--- a/app/src/main/kotlin/uk/co/markormesher/android_fab/app/DemoActivity.kt
+++ b/app/src/main/kotlin/uk/co/markormesher/android_fab/app/DemoActivity.kt
@@ -282,17 +282,17 @@ class DemoActivity: AppCompatActivity() {
 
 	private fun updateButtonPosition() {
 		button_position.text = buttonPositionOptions[buttonPosition].first
-		fab.setButtonPosition(buttonPositionOptions[buttonPosition].second)
+		fab.setPosition(buttonPositionOptions[buttonPosition].second)
 	}
 
 	private fun updateButtonBackgroundColour() {
 		button_background_colour.text = buttonBgColourOptions[buttonBackgroundColour].first
-		fab.setButtonBackgroundColour(buttonBgColourOptions[buttonBackgroundColour].second)
+		fab.setBackgroundColour(buttonBgColourOptions[buttonBackgroundColour].second)
 	}
 
 	private fun updateButtonIcon() {
 		button_icon.text = buttonIconOptions[buttonIcon].first
-		fab.setButtonIconResource(buttonIconOptions[buttonIcon].second)
+		fab.setIconResource(buttonIconOptions[buttonIcon].second)
 	}
 
 	private fun updateSpeedDialSize() {

--- a/fab/src/main/kotlin/uk/co/markormesher/android_fab/FloatingActionButton.kt
+++ b/fab/src/main/kotlin/uk/co/markormesher/android_fab/FloatingActionButton.kt
@@ -29,7 +29,6 @@ import kotlinx.android.synthetic.main.menu_item_icon.view.*
 import uk.co.markormesher.android_fab.extensions.clearParentAlignmentRules
 import uk.co.markormesher.android_fab.fab.R
 
-
 @Suppress("MemberVisibilityCanBePrivate", "unused") // because we want to expose the methods to end users
 class FloatingActionButton: RelativeLayout {
 
@@ -128,13 +127,13 @@ class FloatingActionButton: RelativeLayout {
 			}
 
 			buttonPosition = state.getInt("buttonPosition", buttonPosition)
-			setButtonPosition(buttonPosition)
+			setPosition(buttonPosition)
 
 			buttonBackgroundColour = state.getInt("buttonBackgroundColour", buttonBackgroundColour)
-			setButtonBackgroundColour(buttonBackgroundColour)
+			setBackgroundColour(buttonBackgroundColour)
 
 			buttonIconResource = state.getInt("buttonIconResource", buttonIconResource)
-			setButtonIconResource(buttonIconResource)
+			setIconResource(buttonIconResource)
 
 			contentCoverColour = state.getInt("contentCoverColour", contentCoverColour)
 			setContentCoverColour(contentCoverColour)
@@ -190,9 +189,9 @@ class FloatingActionButton: RelativeLayout {
 	private fun applyAttributes(rawAttrs: AttributeSet?) {
 		val attrs = context.theme.obtainStyledAttributes(rawAttrs, R.styleable.FloatingActionButton, 0, 0)
 		try {
-			setButtonPosition(attrs.getInteger(R.styleable.FloatingActionButton_buttonPosition, buttonPosition))
-			setButtonBackgroundColour(attrs.getColor(R.styleable.FloatingActionButton_buttonBackgroundColour, buttonBackgroundColour))
-			setButtonIconResource(attrs.getResourceId(R.styleable.FloatingActionButton_buttonIcon, 0))
+			setPosition(attrs.getInteger(R.styleable.FloatingActionButton_buttonPosition, buttonPosition))
+			setBackgroundColour(attrs.getColor(R.styleable.FloatingActionButton_buttonBackgroundColour, buttonBackgroundColour))
+			setIconResource(attrs.getResourceId(R.styleable.FloatingActionButton_buttonIcon, 0))
 			setInternalOffsetTop(attrs.getDimension(R.styleable.FloatingActionButton_internalOffsetTop, 0f))
 			setInternalOffsetBottom(attrs.getDimension(R.styleable.FloatingActionButton_internalOffsetBottom, 0f))
 			setInternalOffsetStart(attrs.getDimension(R.styleable.FloatingActionButton_internalOffsetStart, 0f))
@@ -215,34 +214,34 @@ class FloatingActionButton: RelativeLayout {
 	}
 
 	private fun setViewLayoutParams(view: View) {
-		val layoutParams = view.layoutParams as RelativeLayout.LayoutParams
+		val layoutParams = view.layoutParams as LayoutParams
 		layoutParams.clearParentAlignmentRules()
 
 		if (buttonPosition.and(POSITION_TOP) > 0) {
-			layoutParams.addRule(RelativeLayout.ALIGN_PARENT_TOP)
+			layoutParams.addRule(ALIGN_PARENT_TOP)
 		}
 		if (buttonPosition.and(POSITION_BOTTOM) > 0) {
-			layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
+			layoutParams.addRule(ALIGN_PARENT_BOTTOM)
 		}
 		if (buttonPosition.and(POSITION_START) > 0) {
 			if (Build.VERSION.SDK_INT >= 17) {
-				layoutParams.addRule(RelativeLayout.ALIGN_PARENT_START)
+				layoutParams.addRule(ALIGN_PARENT_START)
 			} else {
-				layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
+				layoutParams.addRule(ALIGN_PARENT_LEFT)
 			}
 		}
 		if (buttonPosition.and(POSITION_END) > 0) {
 			if (Build.VERSION.SDK_INT >= 17) {
-				layoutParams.addRule(RelativeLayout.ALIGN_PARENT_END)
+				layoutParams.addRule(ALIGN_PARENT_END)
 			} else {
-				layoutParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
+				layoutParams.addRule(ALIGN_PARENT_RIGHT)
 			}
 		}
 		if (buttonPosition.and(POSITION_LEFT) > 0) {
-			layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT)
+			layoutParams.addRule(ALIGN_PARENT_LEFT)
 		}
 		if (buttonPosition.and(POSITION_RIGHT) > 0) {
-			layoutParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
+			layoutParams.addRule(ALIGN_PARENT_RIGHT)
 		}
 
 		view.layoutParams = layoutParams
@@ -277,7 +276,7 @@ class FloatingActionButton: RelativeLayout {
 		}
 	}
 
-	fun setButtonPosition(position: Int) {
+	fun setPosition(position: Int) {
 		buttonPosition = position
 
 		setViewLayoutParams(fab_card)
@@ -286,7 +285,7 @@ class FloatingActionButton: RelativeLayout {
 		speedDialMenuViews.forEach { setSpeedDialMenuItemViewOrder(it) }
 	}
 
-	fun setButtonBackgroundColour(@ColorInt colour: Int) {
+	fun setBackgroundColour(@ColorInt colour: Int) {
 		buttonBackgroundColour = colour
 		if (Build.VERSION.SDK_INT >= 21) {
 			(fab_card as CardView).setCardBackgroundColor(colour)
@@ -295,7 +294,7 @@ class FloatingActionButton: RelativeLayout {
 		}
 	}
 
-	fun setButtonIconResource(@DrawableRes icon: Int) {
+	fun setIconResource(@DrawableRes icon: Int) {
 		buttonIconResource = icon
 		fab_icon_wrapper.setBackgroundResource(icon)
 	}


### PR DESCRIPTION
Hi, I have a suggestion to simplify the method name. Since this library is for Floating Action **Button** (FAB), I think it's redundant when you define the method name with `.set**Button**....`.

Here I'm trying to simplify the method name.